### PR TITLE
Fix: add default loading functions for shared filtered layers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,9 @@
   "env": {
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
   "rules": {
     "comma-dangle": ["error", "never"],
     "import/no-unresolved": "off",

--- a/src/origofilteretuna.js
+++ b/src/origofilteretuna.js
@@ -514,8 +514,9 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
   }
 
   function removeCqlFilter(layerName) {
-    if (!(currentlyFilteredLayers.some((layer) => layer.get('name') === layerName))) return;
-    const layer = layerName ? viewer.getLayer(layerName) : selectedLayer;
+    const theLayerName = layerName || selectedLayer.get('name');
+    if (!(currentlyFilteredLayers.some((layer) => layer.get('name') === theLayerName))) return;
+    const layer = selectedLayer || viewer.getLayer(layerName);
     document.getElementById(cqlStringTextarea.getId()).value = '';
 
     if (layer.get('type') === 'WMS') {

--- a/src/origofilteretuna.js
+++ b/src/origofilteretuna.js
@@ -2,6 +2,7 @@ import Origo from 'Origo';
 import isOverlapping from './utils/overlapping.js';
 import FtlMapper from './utils/ftl-mapper.js';
 import customWMSLoadFunction from './utils/imageloadfunc.js';
+import getAbsoluteSourceURL from './utils/absolute_url.js';
 
 const Origofilteretuna = function Origofilteretuna(options = {}) {
   let viewer;
@@ -66,8 +67,16 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
   const dom = Origo.ui.dom;
   const layerTypes = ['WMS', 'WFS'];
   const operators = [' = ', ' <> ', ' < ', ' > ', ' <= ', ' >= ', ' like ', ' between '];
-  let defaultWMSImageLoadFunction;
-  let defaultWMSTileLoadFunction;
+  // https://openlayers.org/en/latest/apidoc/module-ol_Image.html#~LoadFunction
+  // https://openlayers.org/en/latest/apidoc/module-ol_Tile.html#~LoadFunction
+  const defaultWMSImageLoadFunction = function defaultWMSImageLoadFunction(image, src) {
+    const WMSImage = image;
+    WMSImage.getImage().src = src;
+  };
+  const defaultWMSTileLoadFunction = (function defaultWMSTileLoadFunction(tile, src) {
+    const WMSTile = tile;
+    WMSTile.getImage().src = src;
+  });
   const currentlyFilteredLayers = [];
 
   const hideButtonWhenEmbedded = 'hideButtonWhenEmbedded' in options ? options.hideButtonWhenEmbedded : false;
@@ -389,50 +398,12 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
     setNumberOfLayersWithFilter(mapIsEmbedded);
   }
 
-  function setSharedFilters() {
-    filterJson.filters.forEach((filter) => {
-      const layer = viewer.getLayer(filter.layerName);
-      if (layer.get('type') === 'WMS') {
-        layer.getSource().updateParams({ layers: filter.layerName, CQL_FILTER: filter.cqlFilter });
-        setIndicators(filter.layerName, viewer.getEmbedded());
-        currentlyFilteredLayers.push(layer);
-      } else if (layer.get('type') === 'WFS') {
-        layer.getSource().once('change', () => {
-          if (layer.getSource().getState() === 'ready') {
-            setWfsFeaturesOnLayer(layer, filter.cqlFilter);
-            setIndicators(filter.layerName, viewer.getEmbedded());
-            currentlyFilteredLayers.push(layer);
-          }
-        });
-      }
-    });
-  }
-
-  function removeFromJson(layerName) {
-    if (layerName) {
-      filterJson.filters.forEach((filter, index) => {
-        if (filter.layerName === layerName) {
-          filterJson.filters.splice(index, 1);
-        }
-      });
-    } else {
-      filterJson = { filters: [] };
-    }
-  }
-
   /**
-   * If source url does not appear absolute
-   * then try to ascertain the current location origin/domain
-  */
-  function getAbsoluteSourceURL(src) {
-    let urlString = src.getUrl === 'function' ? src.getUrl() : src.getUrls()[0];
-
-    if (!urlString.startsWith('http')) {
-      urlString = window.location.origin.concat(urlString);
-    }
-    return urlString;
-  }
-
+   * Sets the load function for a WMS source.
+   *
+   * @param {Object} WMSSource - The WMS source object.
+   * @param {Boolean} setDefaultFunction - Whether to set the predefineddefault load function or a custom one.
+   */
   function setWMSLoadFunction(WMSSource, setDefaultFunction) {
     if (WMSSource.imageLoadFunction) {
       if (setDefaultFunction) {
@@ -457,6 +428,82 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
     returnObj.WMSType = 'tile';
     returnObj.funct = WMSSource.getTileLoadFunction();
     return returnObj;
+  }
+
+  /**
+   * Checks if a layer has another (than this plugin's) custom WMS load function with a POST request.
+   * Checks for the Origo requestMethod param and if necessary the function itself for the 'post' keyword
+   *
+   * @param {Object} layer - The layer object to check.
+   * @return {Boolean} True if the layer has another custom WMS load function with a POST request, false otherwise.
+   */
+  function hasOtherCustomWMSLoadFunctionWithPost(layer) {
+    const mapSources = viewer.getMapSource();
+    const sourceName = layer.get('sourceName');
+    if ((mapSources[sourceName]?.requestMethod) && (mapSources[sourceName].requestMethod.toLowerCase() === 'post')) {
+      return true;
+    }
+    if (layer.get('requestMethod') && (layer.get('requestMethod').toLowerCase() === 'post')) {
+      return true;
+    }
+    const obj = getWMSLoadFunction(layer.getSource());
+    if (obj.funct !== customWMSLoadFunction) {
+      if ((obj.funct.toString().includes('post')) || (obj.funct.toString().includes('POST'))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function setWMSLoadFunctionIfNeeded(WMSSource, layer) {
+    const usesPost = hasOtherCustomWMSLoadFunctionWithPost(layer);
+    const WMSSourceLoadFunctionObj = getWMSLoadFunction(WMSSource);
+    if ((WMSSourceLoadFunctionObj.funct !== customWMSLoadFunction) && (!(usesPost))) {
+      setWMSLoadFunction(WMSSource, false);
+    }
+  }
+
+  function setSharedFilters() {
+    filterJson.filters.forEach((filter) => {
+      const layer = viewer.getLayer(filter.layerName);
+      if (layer.get('type') === 'WMS') {
+        const WMSSource = layer.getSource();
+        setWMSLoadFunctionIfNeeded(WMSSource, layer);
+        let paramsUpdated = false;
+
+        if (layer.getSource().getState() === 'ready') {
+          layer.getSource().updateParams({ layers: filter.layerName, CQL_FILTER: filter.cqlFilter });
+          paramsUpdated = true;
+        }
+        if (!(paramsUpdated)) {
+          layer.getSource().once('change', () => {
+            layer.getSource().updateParams({ layers: filter.layerName, CQL_FILTER: filter.cqlFilter });
+          });
+        }
+        setIndicators(filter.layerName, viewer.getEmbedded());
+        currentlyFilteredLayers.push(layer);
+      } else if (layer.get('type') === 'WFS') {
+        layer.getSource().once('change', () => {
+          if (layer.getSource().getState() === 'ready') {
+            setWfsFeaturesOnLayer(layer, filter.cqlFilter);
+            setIndicators(filter.layerName, viewer.getEmbedded());
+            currentlyFilteredLayers.push(layer);
+          }
+        });
+      }
+    });
+  }
+
+  function removeFromJson(layerName) {
+    if (layerName) {
+      filterJson.filters.forEach((filter, index) => {
+        if (filter.layerName === layerName) {
+          filterJson.filters.splice(index, 1);
+        }
+      });
+    } else {
+      filterJson = { filters: [] };
+    }
   }
 
   function createCqlFilter() {
@@ -485,16 +532,7 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
     if (selectedLayer.get('type') === 'WMS') {
       const WMSSource = selectedLayer.getSource();
       WMSSource.setUrl(getAbsoluteSourceURL(WMSSource));
-
-      // if the current WMS layer does not already have the custom load function then save its original and then set the custom one
-      if (getWMSLoadFunction(WMSSource).funct !== customWMSLoadFunction) {
-        const defaultLoadFunctionObj = getWMSLoadFunction(WMSSource);
-        if (defaultLoadFunctionObj.WMSType === 'image') {
-          defaultWMSImageLoadFunction = defaultLoadFunctionObj.funct;
-        } else defaultWMSTileLoadFunction = defaultLoadFunctionObj.funct;
-        setWMSLoadFunction(WMSSource, false);
-      }
-
+      setWMSLoadFunctionIfNeeded(WMSSource, selectedLayer);
       WMSSource.updateParams({ layers: selectedLayer.get('id'), CQL_FILTER: filterString });
     } else if (selectedLayer.get('type') === 'WFS') {
       setWfsFeaturesOnLayer(selectedLayer, filterString);
@@ -521,8 +559,10 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
 
     if (layer.get('type') === 'WMS') {
       const WMSSource = layer.getSource();
-      setWMSLoadFunction(WMSSource, true);
       WMSSource.updateParams({ layers: layer.get('id'), CQL_FILTER: undefined });
+      if (!(hasOtherCustomWMSLoadFunctionWithPost(layer))) {
+        setWMSLoadFunction(WMSSource, true);
+      }
     } else if (layer.get('type') === 'WFS') {
       setWfsFeaturesOnLayer(layer);
     }
@@ -545,7 +585,9 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
       const layer = currentlyFilteredLayers[i];
       if (layer.get('type') === 'WMS') {
         const WMSSource = layer.getSource();
-        setWMSLoadFunction(WMSSource, true);
+        if (!(hasOtherCustomWMSLoadFunctionWithPost(layer))) {
+          setWMSLoadFunction(WMSSource, true);
+        }
         WMSSource.updateParams({ layers: layer.get('id'), CQL_FILTER: undefined });
       } else if (layer.get('type') === 'WFS') {
         setWfsFeaturesOnLayer(layer);

--- a/src/origofilteretuna.js
+++ b/src/origofilteretuna.js
@@ -514,6 +514,7 @@ const Origofilteretuna = function Origofilteretuna(options = {}) {
   }
 
   function removeCqlFilter(layerName) {
+    if (!(currentlyFilteredLayers.some((layer) => layer.get('name') === layerName))) return;
     const layer = layerName ? viewer.getLayer(layerName) : selectedLayer;
     document.getElementById(cqlStringTextarea.getId()).value = '';
 

--- a/src/utils/absolute_url.js
+++ b/src/utils/absolute_url.js
@@ -1,0 +1,13 @@
+function getAbsoluteSourceURL(src) {
+  let urlString = src;
+  if (typeof src === 'object' && src !== null) {
+    urlString = src.getUrl === 'function' ? src.getUrl() : src.getUrls()[0];
+  }
+
+  if (!urlString.startsWith('http')) {
+    urlString = window.location.origin.concat(urlString);
+  }
+  return urlString;
+}
+
+export default getAbsoluteSourceURL;

--- a/src/utils/imageloadfunc.js
+++ b/src/utils/imageloadfunc.js
@@ -1,5 +1,7 @@
+import getAbsoluteSourceURL from './absolute_url.js';
+
 async function imageLoadFunction(loadedImage, src) {
-  const url = new URL(src.split('?')[0]);
+  const url = new URL(getAbsoluteSourceURL(src).split('?')[0]);
   let objectUrl;
   const img = loadedImage.getImage();
 


### PR DESCRIPTION
Seeks to fix #11 . (It also tries to make sure WMS filters are always applied to shared maps). It does not fetch the current loading functions (on a per source/layer basis or one for all tileWMS layers and one for all imageWMS layers) and save them in the mapstate json because I saw no way to return them to js functions without using some form of eval (`eval()` or `Function()` ) which is frowned upon generally and specifically by our lint rules.

Instead the current OL default loading functions are hardcoded (and made to agree with the project's lint rules). I can't see a real need for another loading function using GET so this PR assumes those that aren't using POST are ok to be left with these OL default loading functions (that they should already have been employing then).  (It seems a bit risky to compare the precise OL default loading functions with every filtered layer's loading function in order to accommodate for custom GET loading functions). This concerns of course changing the loading strategy back to the default after the layer is no longer filtered.